### PR TITLE
Move GHA build to Ubuntu 18.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   medcatmlflow:
-    image: martratas/medcatmlflow:0.1.7
+    image: martratas/medcatmlflow:0.1.8
     ports:
       - 8000:5000
     volumes:


### PR DESCRIPTION
Move GHA to older Ubuntu for (hopefully) better compatibility.