### PR TITLE
Move to Ubuntu 20.04 GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build-and-push:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   medcatmlflow:
-    image: martratas/medcatmlflow:0.1.8
+    image: martratas/medcatmlflow:0.1.9
     ports:
       - 8000:5000
     volumes:


### PR DESCRIPTION
Move to Ubuntu 20.04 GHA.
18.04 doesn't seem to be working. But hopefully still better compatibility than 22.04.